### PR TITLE
Fix button vertical alignment

### DIFF
--- a/paymentMethod.html
+++ b/paymentMethod.html
@@ -52,7 +52,7 @@ Icons made by https://www.flaticon.com/authors/roundicons
 	</header>
 
 	<button class="button" onclick="location.href='....html'">Pay With Coins</button>
-	<button class="button_central" onclick="location.href='....html'">Pay With Credit Card</button>
+	<button class="button" onclick="location.href='....html'">Pay With Credit Card</button>
 	<button class="button" onclick="location.href='....html'">Pay with VANK card</button>
 
 	<div class="cancel_btn">

--- a/resources/a2_styling.css
+++ b/resources/a2_styling.css
@@ -77,6 +77,9 @@ nav img {
 }
 
 .button {
+	margin-left: 		5px;
+	margin-right:		5px;
+	vertical-align: 	top;
 	width: 				200px;
 	height:				200px;
 	background-color: 	transparent;	
@@ -87,23 +90,6 @@ nav img {
 }
 
 .button:hover {
-	background-color: 	#006600;
-	color:				#ffffff;
-}
-
-.button_central {
-	margin-left: 		15px;
-	margin-right:		15px;
-	width: 				200px;
-	height:				200px;
-	background-color: 	transparent;	
-	color: 				black;
-	border: 			2px solid;
-	border-radius: 		8px;
-	font-size: 			20px;
-}
-
-.button_central:hover {
 	background-color: 	#006600;
 	color:				#ffffff;
 }


### PR DESCRIPTION
This is to fix the vertical alignment of the 3 buttons on the `paymentMethod.html` page.
I did this by adding `vertical-alignment: top;` to the button class in css and then removing the `button-central` class.